### PR TITLE
Fix privacy provider method name

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -11,7 +11,7 @@ namespace block_managepages\privacy;
 defined('MOODLE_INTERNAL') || die();
 
 class provider implements \core_privacy\local\metadata\null_provider {
-    public static function _get_reason() {
+    public static function get_reason() {
         return get_string('privacy:metadata', 'block_managepages');
     }
 }


### PR DESCRIPTION
## Summary
- rename `_get_reason()` to `get_reason()` in privacy provider

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6844c30650388321a47470ebd93f2864