### PR TITLE
Add clipboard JSON handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Ce plugin Moodle permet aux utilisateurs de sélectionner des activités de type
 - Sélection facile des activités de type "page".
 - Exportation en format Markdown.
 - Téléchargement en un seul fichier ZIP si plusieurs pages sont sélectionnées.
+- Copie rapide du Markdown dans le presse-papier.
 
 ## Contribuer
 

--- a/export.php
+++ b/export.php
@@ -56,6 +56,25 @@ if (optional_param('ajax', 0, PARAM_INT) == 3 && $_SERVER['REQUEST_METHOD'] === 
     exit;
 }
 
+// Gestion AJAX de l'export vers le presse-papier
+if (optional_param('ajax', 0, PARAM_INT) == 1) {
+    $pageids = optional_param_array('page_ids', [], PARAM_INT);
+    if (empty($pageids)) {
+        header('Content-Type: application/json');
+        http_response_code(400);
+        echo json_encode(['error' => get_string('error:nopagesselected', 'block_managepages')]);
+        exit;
+    }
+    $context = context_course::instance($courseid);
+    require_capability('block/managepages:export', $context);
+    $exporter = new \block_managepages\exporter();
+    $pages = $exporter->fetch_selected_pages($pageids, $courseid);
+    $markdown = $exporter->get_structured_markdown($pages, $courseid);
+    header('Content-Type: application/json');
+    echo json_encode(['markdown' => $markdown]);
+    exit;
+}
+
 // Ensuite SEULEMENT la logique d'export classique
 $pageids = optional_param_array('page_ids', [], PARAM_INT);
 if (empty($pageids)) {


### PR DESCRIPTION
## Summary
- fix AJAX flow for copy-to-clipboard
- document clipboard feature

## Testing
- `php -l export.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c5fb9b7c832183b4b9117a25dc1c