### PR TITLE
Handle missing courseid in block_managepages

### DIFF
--- a/classes/output/main.php
+++ b/classes/output/main.php
@@ -52,7 +52,8 @@ class main implements renderable, templatable {
         return [
             'sections' => array_values($arbo),
             'exporturl' => new \moodle_url('/blocks/managepages/export.php', ['courseid' => $this->courseid]),
-            'sesskey' => sesskey()
+            'sesskey' => sesskey(),
+            'courseid' => $this->courseid
         ];
     }
 }

--- a/templates/block_managepages.mustache
+++ b/templates/block_managepages.mustache
@@ -2,6 +2,7 @@
     <h2>{{#str}} select_pages, block_managepages {{/str}}</h2>
     <form method="post" action="{{{exporturl}}}" id="export-form">
         <input type="hidden" name="sesskey" value="{{sesskey}}" />
+        <input type="hidden" id="block-managepages-courseid" value="{{courseid}}" />
         <div>
             <label>{{#str}} select_page_label, block_managepages {{/str}}</label>
             <div style="max-height:350px; overflow-y:auto; border:1px solid #ccc; padding:8px; width:100%;">
@@ -49,6 +50,12 @@
                 return;
             }
             var courseid = new URLSearchParams(window.location.search).get('id');
+            if (!courseid) {
+                var courseInput = document.getElementById('block-managepages-courseid');
+                if (courseInput) {
+                    courseid = courseInput.value;
+                }
+            }
             var sesskey = document.querySelector('input[name="sesskey"]').value;
             var response = await fetch(M.cfg.wwwroot + '/blocks/managepages/export.php?ajax=1&sesskey=' + encodeURIComponent(sesskey) + '&courseid=' + courseid + '&page_ids[]=' + selected.join('&page_ids[]='));
             if (response.ok) {
@@ -69,6 +76,12 @@
                 e.preventDefault();
                 var pageid = btn.getAttribute('data-pageid');
                 var courseid = new URLSearchParams(window.location.search).get('id');
+                if (!courseid) {
+                    var courseInput = document.getElementById('block-managepages-courseid');
+                    if (courseInput) {
+                        courseid = courseInput.value;
+                    }
+                }
                 var sesskey = document.querySelector('input[name="sesskey"]').value;
                 try {
                     var response = await fetch(M.cfg.wwwroot + '/blocks/managepages/export.php?ajax=2&sesskey=' + encodeURIComponent(sesskey) + '&courseid=' + courseid + '&pageid=' + pageid);


### PR DESCRIPTION
## Summary
- expose `courseid` in `export_for_template`
- store the course id in a hidden input in the template
- use hidden input to fall back when URL parameter `id` is missing

## Testing
- `php -l classes/output/main.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844cd8cad0083219ed535a299dc54e2