### PR TITLE
Fix init event

### DIFF
--- a/templates/block_managepages.mustache
+++ b/templates/block_managepages.mustache
@@ -141,7 +141,7 @@
             };
         }
     }
-    window.addEventListener('load', block_managepages_init);
+    window.addEventListener('DOMContentLoaded', block_managepages_init);
     </script>
     {{#message}}
         <div class="message">{{message}}</div>


### PR DESCRIPTION
## Summary
- load block_managepages script on `DOMContentLoaded`

## Testing
- `php -l` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d046d5348321a6dbdbab68697f3e