### PR TITLE
Use navigator.clipboard with fallback

### DIFF
--- a/templates/block_managepages.mustache
+++ b/templates/block_managepages.mustache
@@ -62,8 +62,12 @@
                 var data = await response.json();
                 textarea.value = data.markdown;
                 textarea.style.display = 'block';
-                textarea.select();
-                document.execCommand('copy');
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(textarea.value);
+                } else {
+                    textarea.select();
+                    document.execCommand('copy');
+                }
                 textarea.style.display = 'none';
                 alert('Contenu copié dans le presse-papier !');
             } else {


### PR DESCRIPTION
## Summary
- copy Markdown using `navigator.clipboard.writeText` when available
- fall back to the old `execCommand('copy')` for older browsers

## Testing
- `php -l block_managepages.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844d04556108321aeea7a76207d93ab