### PR TITLE
Use __DIR__ for config include

### DIFF
--- a/export.php
+++ b/export.php
@@ -6,7 +6,7 @@
  * @copyright   2025 Maxime Cruzel
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-require_once('../../config.php');
+require_once(__DIR__ . '/../../config.php');
 require_login();
 require_sesskey();
 $courseid = required_param('courseid', PARAM_INT);


### PR DESCRIPTION
## Summary
- reference config using `__DIR__` for portability

## Testing
- `php -l export.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d16d5e188321ba88d3c498f186d2