### PR TITLE
Handle missing course context when rendering block

### DIFF
--- a/block_managepages.php
+++ b/block_managepages.php
@@ -44,10 +44,40 @@ class block_managepages extends block_base {
      * @return string
      */
     private function render_export_form() {
-        global $OUTPUT, $COURSE;
-        $renderable = new \block_managepages\output\main($COURSE->id);
+        global $OUTPUT;
+        $courseid = $this->resolve_courseid();
+        $renderable = new \block_managepages\output\main($courseid);
         $template = 'block_managepages/block_managepages';
         return $OUTPUT->render_from_template($template, $renderable->export_for_template($OUTPUT));
+    }
+
+    /**
+     * Résout l'identifiant du cours à partir du contexte ou des paramètres de la requête.
+     *
+     * @return int
+     * @throws moodle_exception Lorsque le cours ne peut pas être déterminé.
+     */
+    private function resolve_courseid(): int {
+        global $COURSE;
+
+        if (!empty($COURSE) && !empty($COURSE->id)) {
+            return (int) $COURSE->id;
+        }
+
+        if (!empty($this->page) && !empty($this->page->course) && !empty($this->page->course->id)) {
+            return (int) $this->page->course->id;
+        }
+
+        $courseid = optional_param('courseid', 0, PARAM_INT);
+        if (!$courseid) {
+            $courseid = optional_param('id', 0, PARAM_INT);
+        }
+
+        if ($courseid) {
+            return (int) $courseid;
+        }
+
+        throw new \moodle_exception('error:missingcourseid', 'block_managepages');
     }
 
     /**

--- a/lang/en/block_managepages.php
+++ b/lang/en/block_managepages.php
@@ -9,6 +9,7 @@ $string['download'] = 'Download';
 $string['download_all'] = 'Download all';
 $string['error:nopagesselected'] = 'No page selected. Please select at least one page.';
 $string['error:zipcreationfailed'] = 'An error occurred while creating the ZIP file. Please try again.';
+$string['error:missingcourseid'] = 'Unable to determine the course for this block.';
 $string['privacy:metadata'] = 'This plugin does not store personal data.';
 $string['edit'] = 'Edit';
 $string['edit_page_title'] = 'Edit: {$a}';

--- a/lang/fr/block_managepages.php
+++ b/lang/fr/block_managepages.php
@@ -9,6 +9,7 @@ $string['download'] = 'Télécharger';
 $string['download_all'] = 'Tout télécharger';
 $string['error:nopagesselected'] = 'Aucune page sélectionnée. Veuillez sélectionner au moins une page.';
 $string['error:zipcreationfailed'] = 'Erreur lors de la création du fichier ZIP. Veuillez réessayer.';
+$string['error:missingcourseid'] = 'Impossible de déterminer le cours associé à ce bloc.';
 $string['privacy:metadata'] = 'Ce plugin ne stocke aucune donnée personnelle.';
 $string['edit'] = 'Modifier';
 $string['edit_page_title'] = 'Modifier : {$a}';

--- a/tests/block_managepages_test.php
+++ b/tests/block_managepages_test.php
@@ -131,17 +131,36 @@ class block_managepages_test extends \advanced_testcase {
         // Create test course without pages
         $course = $this->getDataGenerator()->create_course();
         $this->setCurrentCourse($course);
-        
+
         // Create block and get content
         $block = new \block_managepages();
         $block->init();
-        
+
         global $COURSE;
         $COURSE = $course;
-        
+
         $content = $block->get_content();
-        
+
         // Should still return content even with no pages
+        $this->assertNotNull($content);
+        $this->assertNotNull($content->text);
+    }
+
+    /**
+     * Test block behaviour when global course is missing but page context is available.
+     */
+    public function test_block_content_without_global_course() {
+        $course = $this->getDataGenerator()->create_course();
+        $this->setCurrentCourse($course);
+
+        global $COURSE;
+        $COURSE = null;
+
+        $block = new \block_managepages();
+        $block->init();
+
+        $content = $block->get_content();
+
         $this->assertNotNull($content);
         $this->assertNotNull($content->text);
     }

--- a/version.php
+++ b/version.php
@@ -9,7 +9,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_managepages';
-$plugin->version = 2025060806; // YYYYMMDDHH (year, month, day, 24-hr time)
+$plugin->version = 2025101700; // YYYYMMDDHH (year, month, day, 24-hr time)
 $plugin->requires = 2022041900; // Requires this Moodle version
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '1.2.3'; // Human-readable version name


### PR DESCRIPTION
## Summary
- resolve the course id before rendering so the block no longer relies on a nullable global
- add a dedicated error message when no course can be detected
- cover the new fallback with a PHPUnit test scenario
- bump the plugin version for the new release

## Testing
- not run (requires full Moodle PHPUnit environment)

------
https://chatgpt.com/codex/tasks/task_e_68f16ff5fec083218dfa014aac3270b8